### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-*** Check LICENSE for licensing conditions. ***
+*Check LICENSE for licensing conditions.*
 
-=== Modbat: Model-based Tester ===
+# Modbat: Model-based Tester
 
 Modbat is specialized to testing the application programming interface
 (API) of software. The model used by Modbat is compatible with Java
@@ -8,7 +8,7 @@ bytecode. The user defines and compiles a model, which is then explored
 by Modbat and executed against the system under test. Failed test runs
 are reported as an error trace.
 
---- Installation ---
+## Installation
 
 Requirements: Scala 2.11 or higher (tested on 2.11.1).
 
@@ -17,29 +17,31 @@ modbat-examples.jar. The first file is an executable JAR file that has to
 be run using the Scala runtime environment. The second file is optional
 and contains examples.
 
---- Model syntax ---
+## Model syntax
 
 A Modbat model inherits from modbat.dsl.Model. Inside the class body
 (effectively, its default constructor), model transitions can be declared:
 
-	package modbat
+```scala
+package modbat
 
-	import modbat.dsl._
+import modbat.dsl._
 
-	class ModelTemplate extends Model {
-	  // transitions
-	  "reset" -> "somestate" := {
-	    // insert code here
-	  }
-	  "somestate" -> "end" := skip // empty transition function
-	  "reset" -> "end" := {
-	  }
-	}
+class ModelTemplate extends Model {
+  // transitions
+  "reset" -> "somestate" := {
+    // insert code here
+  }
+  "somestate" -> "end" := skip // empty transition function
+  "reset" -> "end" := {
+  }
+}
+```
 
 Note that direct calls to functions are possible; curly braces are only
 needed to group multiple statements inside a transition function.
 
---- Basic usage ---
+## Basic usage
 
 The examples below assume that Modbat is compiled into build/, so
 the commands below have to be preceded with
@@ -66,7 +68,7 @@ file using
 The examples are contained in modbat/examples, while the template
 is in modbat/ModelTemplate.scala.
 
---- Semantics of basic models ---
+## Semantics of basic models
 
 See the following publication:
 
@@ -76,7 +78,7 @@ Modbat: A Model-based API Tester for Event-driven Systems.
 9th Haifa Verification Conference (HVC 2013), November 2013,
 Haifa, Israel.
 
---- How to run the examples ---
+## How to run the examples
 
 Usage is as above. The examples can be run either from the JAR file
 examples.jar, or using the class files from the unpacked JAR file.
@@ -131,7 +133,7 @@ also map one issue to two failures (in case multiple transitions
 trigger the same fauilure). However, it gives a good overview if
 a model exhibits multiple types of failures.
 
---- How to read the error trace ---
+## How to read the error trace
 
 If a model run causes an assertion violation or other unhandled exception,
 an error trace is generated in a .err file. The name of the .err file
@@ -149,32 +151,38 @@ Example:
 
 Note that the random seed must not be 0.
 
---- Semantics of model ---
+## Semantics of model
 
 The model is given as an "extended finite state machine" in a
 domain-specific language that is embedded in Scala. Basic transitions
 between two states are given as
 
-	"pre" -> "post"
+```scala
+"pre" -> "post"
+```
 
 Most transitions will have a transition function attached to them, using
 ":="
 
-	"pre" -> "post" := { // Scala code }
+```scala
+"pre" -> "post" := { // Scala code }
+```
 
 Any Scala code is allowed, but preconditions have a special semantics:
 Exploration of the model backtracks if a precondition is violated.
 Therefore, all preconditions should be stated at the beginning of a
 transition function, and be side-effect-free:
 
-	"pre" -> "post" := {
-		require (x < 0)
-	}
+```scala
+"pre" -> "post" := {
+	require (x < 0)
+}
+```
 
 A model will contain multiple transitions, separated by a comma, as
 shown in src/scala/modbat/ModelTemplate.scala.
 
---- Preconditions and assertions ---
+## Preconditions and assertions
 
 Preconditions are defined by "require(predicate)". If a precondition
 fails in the model, the transition is considered not to be eligible,
@@ -201,13 +209,13 @@ in unintended effects if an assertion fails in a separate thread:
     Modbat assert fails in model -> stop (directly or before next transition);
     Predef assert fails -> stop if in main thread, no effect otherwise.
 
---- Inheritance ---
+## Inheritance
 
 Inheritance of methods works normally as in Scala. Transitions defined
 normally ("a" -> "b" := transfunc) are also inherited, as are annotated
 methods from the super class.
 
---- Advanced features ---
+## Advanced features
 
 Advanced choices give flexibility when modeling non-determinism:
 
@@ -229,9 +237,11 @@ function. These are:
 
 * throws:
 
-	"pre" -> "post" := {
-		codeThrowingException
-	} throws("IOException", "SecurityException")
+```scala
+"pre" -> "post" := {
+	codeThrowingException
+} throws("IOException", "SecurityException")
+```
 
 "throws" specifies that an exception must always occur in that transition;
 the absence of an exception is regarded as an error.  A list of exception
@@ -241,9 +251,11 @@ Pattern "Exception" will match almost anything.
 
 * catches:
 
-	"pre" -> "post" := {
-		codeWithPossibleException
-	} catches("Exception" -> "handlerState")
+```scala
+"pre" -> "post" := {
+	codeWithPossibleException
+} catches("Exception" -> "handlerState")
+```
 
 "catches" deals with non-deterministic exceptions that may occur, but
 are not always expected. Input/output errors can be handled in the model
@@ -259,9 +271,11 @@ next executed transition is one of the available transitions in state
 
 * nextIf:
 
-	"pre" -> "post" := {
-		n = choose(0, 40)
-	} nextIf({ () => n > 30 } -> "nextState")
+```scala
+"pre" -> "post" := {
+	n = choose(0, 40)
+} nextIf({ () => n > 30 } -> "nextState")
+```
 
 Non-deterministic conditions other than exceptions can be handled using
 "nextIf"; given a list of (condition, nextState) pairs, the transition
@@ -272,9 +286,11 @@ Conditions are usually given as an anonymous function in Scala, using the
 
 * maybe:
 
-	"pre" -> "post" := {
-		maybe (doSomething)
-	}
+```scala
+"pre" -> "post" := {
+	maybe (doSomething)
+}
+```
 
 An action is only executed with a certain probability (default: 0.5).
 If a random number between 0 and 1 exceeds that probability, then the
@@ -287,10 +303,12 @@ the state of the model or SUT via side effects.
 "maybe" can be used with an optional "or_else", which executes only
 if "maybe" is not chosen, similar to an "if"/"else" statement:
 
-	"pre" -> "post" := {
-		maybe (doSomething)
-		or_else (doSomethingElse)
-	}
+```scala
+"pre" -> "post" := {
+	maybe (doSomething)
+	or_else (doSomethingElse)
+}
+```
 
 * maybeBool:
 
@@ -299,15 +317,19 @@ Same as "maybe" but returns a boolean. If the function is not executed
 
 * maybeNextIf:
 
-	"pre" -> "post" := {
-		n = choose(0, 40)
-	} maybeNextIf({ () => n > 30 } -> "nextState")
+```scala
+"pre" -> "post" := {
+	n = choose(0, 40)
+} maybeNextIf({ () => n > 30 } -> "nextState")
+```
 
 Same as "nextIf", but the condition is only evaluated with a certain
 probability (default: 0.5). Otherwise, the given condition is ignored,
 and the default transition is chosen. This function is syntactic sugar for
 
-	nextIf({ () => maybeBool({ () => n > 30 }) } -> "nextState")
+```scala
+nextIf({ () => maybeBool({ () => n > 30 }) } -> "nextState")
+```
 
 * label:
 
@@ -316,7 +338,9 @@ by looking at the code of the transition function. The result is not
 always the best possible description, but it is possible to override
 the default label with a "label" declaration following the transition:
 
-	"pre" -> "post" := { code } label "initialization"
+```scala
+"pre" -> "post" := { code } label "initialization"
+```
 
 The label is not used in the error trace as the state information,
 together with the code location, is already sufficient to identify
@@ -329,9 +353,11 @@ a weight > 1.0 to it. Weights are integers representing how often a
 transition is represented w.r.t. the default weight 1.0. A weight of 0
 disables a transition:
 
-	"pre" -> "post" := { code } weight 2
+```scala
+"pre" -> "post" := { code } weight 2
+```
 
---- API functions ---
+## API functions
 
 In addition to variants of choose (see above), Modbat also has other API
 functions:
@@ -348,7 +374,7 @@ functions:
   (see below): Returns whether the just-finished test failed. Undefined
   otherwise.
 
---- Observer models ---
+## Observer models
 
 If a model extends Observer (rather than Model), it is considered to
 be a passive observer state machine. These machines have the following
@@ -369,11 +395,11 @@ key differences compared to normal Modbat models:
 With registered observers, model execution therefore works in an
 alternating fashion:
 
-1) Execute an eligible transition from one of all available models.
+1. Execute an eligible transition from one of all available models.
 
-2) Execute all eligible transitions from all available observers.
+2. Execute all eligible transitions from all available observers.
 
---- Helper method annotations ---
+## Helper method annotations
 
 Modbat supports several method annotations. These methods are invoked
 at certain times. Annotated methods must take zero arguments, or they
@@ -438,9 +464,11 @@ declaring class. An inherited annotated method will NOT be recognized
 and used! To use inheritance, declare another annotated method that
 delegates the call, such as
 
-	@Before def setup { super.setup }
+```scala
+@Before def setup { super.setup }
+```
 
---- Field annotations ---
+## Field annotations
 
 Modbat currently supports one model field annotation, @Trace.
 Model fields with this annotation are traced throughout test execution.
@@ -448,16 +476,16 @@ After each step, all annotated fields of the model whose transition
 just executed, is checked for updates of these fields. Updates are
 logged and shown as part of the error trace.
 
---- Visualization ---
+## Visualization
 
 The tool supports a basic visualization (requiring graphviz), using
 
 	scala modbat.jar --mode=dot <model>
 
-The output file is <modelname>.dot. The destination directory can
+The output file is `<modelname>.dot`. The destination directory can
 be changed using --dot-dir=...; default is the current directory.
 
---- How to compile your own model ---
+## How to compile your own model
 
 It is recommended that you copy ModelTemplate.scala to create your own
 model. Compilation of a model requires modbat.jar in the classpath.
@@ -467,7 +495,7 @@ directory, use:
 
 	scalac -cp modbat.jar Model.scala
 
---- Replaying traces ---
+## Replaying traces
 
 Error traces can be reproduced by supplying the same random seed to
 Modbat. For example, a test on modbat.examples.NioSocket1 produces a
@@ -481,14 +509,14 @@ When replaying a trace, Modbat explores the model again, making the same
 choices as originally made when the random number generator was in a
 given state.
 
---- Other test configuration options ---
+## Other test configuration options
 
 Also see the output of "scala modbat/modbat.jar -h".
 
 Note that a loop limit of 1 means no loops will be allowed, so
 self-loops will never be executed.
 
---- Troubleshooting ---
+## Troubleshooting
 
 At this stage, many problems encountered are class path/class loader
 issues. Please check the following:

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ has the same effect unless option --precond-as-failure is used.
 This distinction is possible because Modbat defines its own "require"
 implementation, resulting in two cases:
 
-    Modbat require fails in model -> backtrack;
-    Predef require fails in SUT   -> backtrack or abort (according to option).
+* Modbat require fails in model -> backtrack;
+* Predef require fails in SUT   -> backtrack or abort (according to option).
 
 Assertions behave in the same way in both the model and the SUT, but
 standard assertions that fail in a separate thread (not the main thread)
@@ -206,8 +206,8 @@ the model, if multiple threads or asynchronous callbacks are used.
 Assertions are therefore evaluated in two possible ways, which may result
 in unintended effects if an assertion fails in a separate thread:
 
-    Modbat assert fails in model -> stop (directly or before next transition);
-    Predef assert fails -> stop if in main thread, no effect otherwise.
+* Modbat assert fails in model -> stop (directly or before next transition);
+* Predef assert fails -> stop if in main thread, no effect otherwise.
 
 ## Inheritance
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Requirements: [Gradle Build Tool](https://gradle.org/) version 4.
 
 Clone the repository and `cd` into it.
 
-    $ git clone https://github.com/cyrille-artho/modbat.git
-    $ cd modbat
+    git clone https://github.com/cyrille-artho/modbat.git
+    cd modbat
 
 Assemble the project by running:
 
-    modbat$ gradle assemble
+    gradle assemble
 
 This will build the project and place the JAR files in "./build".
 
@@ -61,21 +61,21 @@ needed to group multiple statements inside a transition function.
 Modbat is run by executing the modbat.jar file which is placed
 in the ./build directory during compilation by default.
 
-	modbat$ cd build
-	modbat/build$ scala modbat.jar [OPTIONS] MODELCLASS...
+	cd build
+	scala modbat.jar [OPTIONS] MODELCLASS...
 
 For help, try
 
-	modbat/build$ scala modbat.jar -h
+	scala modbat.jar -h
 
 and to check the current configuration, use
 
-	modbat/build$ scala modbat.jar -s
+	scala modbat.jar -s
 
 The second file contains examples and a model template; unpack that
 file using
 
-	modbat/build$ jar xf modbat-examples.jar
+	jar xf modbat-examples.jar
 
 The examples are contained in modbat/examples, while the template
 is in modbat/ModelTemplate.scala.
@@ -157,7 +157,7 @@ output to a file, use
 
 Example:
 
-	modbat/build$ scala modbat.jar --classpath=modbat-examples.jar \
+	scala modbat.jar --classpath=modbat-examples.jar \
     -n=1 -s=2455cfedeadbeef \
 		--no-redirect-out \
 		modbat.examples.SimpleModel
@@ -544,7 +544,7 @@ failure using random seed 61a342c60d18ff4d. The random seed is used as
 the name of the file containing the error trace (61a342c60d18ff4d.err).
 It can also be used to reproduce the same trace:
 
-	modbat/build$ scala modbat.jar --classpath=modbat-examples.jar \
+	scala modbat.jar --classpath=modbat-examples.jar \
                                  -n=1 -s=61a342c60d18ff4d \
                                  modbat.examples.NioSocket1
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clone the repository and `cd` into it.
 
 Assemble the project by running:
 
-    $ gradle assemble
+    modbat$ gradle assemble
 
 This will build the project and place the JAR files in "./build".
 
@@ -61,21 +61,21 @@ needed to group multiple statements inside a transition function.
 Modbat is run by executing the modbat.jar file which is placed
 in the ./build directory during compilation by default.
 
-	cd build
-	scala modbat.jar [OPTIONS] MODELCLASS...
+	modbat$ cd build
+	modbat/build$ scala modbat.jar [OPTIONS] MODELCLASS...
 
 For help, try
 
-	scala modbat.jar -h
+	modbat/build$ scala modbat.jar -h
 
 and to check the current configuration, use
 
-	scala modbat.jar -s
+	modbat/build$ scala modbat.jar -s
 
 The second file contains examples and a model template; unpack that
 file using
 
-	jar xf modbat-examples.jar
+	modbat/build$ jar xf modbat-examples.jar
 
 The examples are contained in modbat/examples, while the template
 is in modbat/ModelTemplate.scala.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ modbat-examples.jar. The first file is an executable JAR file that has to
 be run using the Scala runtime environment. The second file is optional
 and contains examples.
 
+### Building from source
+
+Requirements: [Gradle Build Tool](https://gradle.org/) version 4.
+
+Clone the repository and `cd` into it.
+
+    $ git clone https://github.com/cyrille-artho/modbat.git
+    $ cd modbat
+
+Assemble the project by running:
+
+    $ gradle assemble
+
+This will build the project and place the JAR files in "./build".
+
 ## Model syntax
 
 A Modbat model inherits from modbat.dsl.Model. Inside the class body

--- a/README.md
+++ b/README.md
@@ -502,6 +502,30 @@ The tool supports a basic visualization (requiring graphviz), using
 The output file is `<modelname>.dot`. The destination directory can
 be changed using --dot-dir=...; default is the current directory.
 
+Example:
+
+    modbat/build$ scala modbat.jar --classpath=modbat-examples.jar \
+                                   --mode=dot \
+                                   -n=1 -s=2455cfedeadbeef \
+                                   --no-redirect-out \
+                                   modbat.examples.SimpleModel
+    modbat/build$ cat modbat.examples.SimpleModel.dot
+    digraph model {
+      orientation = landscape;
+      graph [ rankdir = "TB", ranksep="0.4", nodesep="0.2" ];
+      node [ fontname = "Helvetica", fontsize="12.0", margin="0.07" ];
+      edge [ fontname = "Helvetica", fontsize="12.0", margin="0.05" ];
+      "" [ shape = "point", height="0.1" ];
+      "" -> reset
+      reset -> zero [ label = " new SimpleCounter " ];
+      zero  -> zero [ label = " toggleSwitch " ];
+      zero  -> one [ label = " inc " ];
+      one   -> two [ label = " inc " ];
+      zero  -> two [ label = " inc2 " ];
+      two   -> end [ label = " assert " ];
+    }
+
+
 ## How to compile your own model
 
 It is recommended that you copy ModelTemplate.scala to create your own

--- a/README.md
+++ b/README.md
@@ -58,13 +58,10 @@ needed to group multiple statements inside a transition function.
 
 ## Basic usage
 
-The examples below assume that Modbat is compiled into build/, so
-the commands below have to be preceded with
+Modbat is run by executing the modbat.jar file which is placed
+in the ./build directory during compilation by default.
 
 	cd build
-
-once.
-
 	scala modbat.jar [OPTIONS] MODELCLASS...
 
 For help, try
@@ -160,7 +157,8 @@ output to a file, use
 
 Example:
 
-	scala modbat.jar -n=1 -s=2455cfedeadbeef \
+	modbat/build$ scala modbat.jar --classpath=modbat-examples.jar \
+    -n=1 -s=2455cfedeadbeef \
 		--no-redirect-out \
 		modbat.examples.SimpleModel
 
@@ -522,7 +520,9 @@ failure using random seed 61a342c60d18ff4d. The random seed is used as
 the name of the file containing the error trace (61a342c60d18ff4d.err).
 It can also be used to reproduce the same trace:
 
-	scala modbat.jar -n=1 -s=61a342c60d18ff4d modbat.examples.NioSocket1
+	modbat/build$ scala modbat.jar --classpath=modbat-examples.jar \
+                                 -n=1 -s=61a342c60d18ff4d \
+                                 modbat.examples.NioSocket1
 
 When replaying a trace, Modbat explores the model again, making the same
 choices as originally made when the random number generator was in a

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ given state.
 
 ## Other test configuration options
 
-Also see the output of "`scala modbat/modbat.jar -h`".
+Also see the output of "`scala build/modbat.jar -h`".
 
 Note that a loop limit of 1 means no loops will be allowed, so
 self-loops will never be executed.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*Check LICENSE for licensing conditions.*
+*Check [LICENSE](LICENSE) for licensing conditions.*
 
 # Modbat: Model-based Tester
 

--- a/README.md
+++ b/README.md
@@ -405,26 +405,30 @@ Modbat supports several method annotations. These methods are invoked
 at certain times. Annotated methods must take zero arguments, or they
 will be ignored. Supported annotations include:
 
-* @States(Array("state1" [, "state2"[, ...]])):
+* `@States(Array("state1" [, "state2"[, ...]]))`:
   This annotation specifies that the given action may be executed
   at any time at a given state. It gets executed like any regular
   model transition, but it does not change the model state.
   This annotation results in self-loop transitions being added to
   the model before it is executed. For example
 
+  ```scala
   @States(Array("state1", "state2")) def invariantCheck { ... }
+  ```
 
   results in transitions
 
+  ```scala
   "state1" -> "state1" := invariantCheck
   "state2" -> "state2" := invariantCheck
+  ```
 
-* @Throws(Array("Exception1" [, ...])):
+* `@Throws(Array("Exception1" [, ...]))`:
   If used together with "@States", specifies which exceptions this
   method is expected to throws. Counterpart to ``throws "Exception1"``
   for normal model transitions.
 
-* @Weight(double):
+* `@Weight(double)`:
   If used together with "@States", specifies the weight for each resulting
   transition function. As one copy of the function is created for each
   self-loop, such functions would be executed very often if their weight
@@ -434,15 +438,15 @@ will be ignored. Supported annotations include:
   SUT state (such as invariant checks). For functions modifying
   parts of the SUT, consider using @Weight(1.0).
 
-* @Init: The given method is executed before the first test is run,
+* `@Init`: The given method is executed before the first test is run,
   but not before each test. This is useful, for example, to execute
   a server instance for testing client-side behavior, as is done in
   model modbat.test.JavaNioSocket.
 
-* @Shutdown: This method is executed after the last test completes,
+* `@Shutdown`: This method is executed after the last test completes,
   or when Modbat is forcibly shut down by signal TERM.
 
-* @Before: This action is execute before each test is executed, but
+* `@Before`: This action is execute before each test is executed, but
   not when a new instance model is launched. This annotation therefore
   allows a differentiation between the need to initialize data before
   each test (using the annotation) or before a model instance is
@@ -450,12 +454,12 @@ will be ignored. Supported annotations include:
   functionality of the model). The action is executed on the default
   instance of the model.
 
-* @After: This action is executed after each test execution run,
+* `@After`: This action is executed after each test execution run,
   on the default instance of the model.
 
-@Before annotations are also executed on a newly launched model instance
+`@Before` annotations are also executed on a newly launched model instance
 (using launch), right when the model is launched (while the transition
-of the parent model is executing). @After annotations are also executed
+of the parent model is executing). `@After` annotations are also executed
 on all launched model instances at the end of a given test (regardless
 of when a model instance completed its last transition).
 
@@ -470,7 +474,7 @@ delegates the call, such as
 
 ## Field annotations
 
-Modbat currently supports one model field annotation, @Trace.
+Modbat currently supports one model field annotation, `@Trace`.
 Model fields with this annotation are traced throughout test execution.
 After each step, all annotated fields of the model whose transition
 just executed, is checked for updates of these fields. Updates are
@@ -511,7 +515,7 @@ given state.
 
 ## Other test configuration options
 
-Also see the output of "scala modbat/modbat.jar -h".
+Also see the output of "`scala modbat/modbat.jar -h`".
 
 Note that a loop limit of 1 means no loops will be allowed, so
 self-loops will never be executed.
@@ -523,7 +527,7 @@ issues. Please check the following:
 
 * CLASSPATH setting.
 
-* Use "scala modbat.jar --classpath=..." to override this setting.
+* Use "`scala modbat.jar --classpath=...`" to override this setting.
 
 * Note that any CLASSPATH setting or -cp/-classpath argument to
   scala itself is ignored when using an executable JAR file.
@@ -538,5 +542,7 @@ issues. Please check the following:
 * Scala compiler errors: If you get "error: reassignment to val" for
   each transition declaration (at ":="), then you have probably
   accidentally deleted the import statement:
+  ```scala
   import modbat.dsl._
+  ```
   This statement is necessary for internal type conversions.


### PR DESCRIPTION
fixes #10 
* README changed to markdown
* Instructions on how to build with gradle

As for updating the instructions to reflect that the jars are put in ./build I'm not sure how clear
it should be. In some places I've prefixed shell commands like `modbat/build$ <COMMAND>`
to make it clear that they should be executed in the build directory, but I'm not sure It's helpful
to write that in every command example. This is what that would look like:

## Basic usage
Modbat is run by executing the modbat.jar file which is placed
in the ./build directory during compilation by default.

    modbat$ cd build
    modbat/build$ scala modbat.jar [OPTIONS] MODELCLASS...

For help, try

    modbat/build$ scala modbat.jar -h

and to check the current configuration, use

    modbat/build$ scala modbat.jar -s

The second file contains examples and a model template; unpack that
file using

    modbat/build$ jar xf modbat-examples.jar