### PR TITLE
Include akka-actor dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,13 @@ jar {
     }
     from "LICENSE", "README", "CHANGELOG", "asm-LICENSE", "sourcecode-LICENSE", "akka-mock-LICENSE", "javassist-LICENSE"
     from "config/build/classes/java/main", "config/build/classes/scala/main"
-    from configurations.runtimeClasspath.
-                                         findAll { it.name.endsWith('jar') && ((it.name.contains('asm') || it.name.contains('javassist') || it.name.contains('sourcecode') ||  it.name.contains('akka-mock'))) }.
-                                         collect { zipTree(it) }
+    from configurations.runtimeClasspath.findAll { it.name.endsWith('jar') && (
+                                            it.name.contains('asm') || 
+                                            it.name.contains('javassist') || 
+                                            it.name.contains('sourcecode') ||  
+                                            it.name.contains('akka-mock') ||
+                                            it.name.contains('akka-actor')
+                                          ) }.collect { zipTree(it) }
 }
 
 apply plugin: "com.github.maiflai.scalatest"


### PR DESCRIPTION
As discussed in issue #91 , I'm no gradle expert but this seems to match the way you have done before.
Unsurprisingly passes both tests:
```
./gradlew test
bin/test.sh
```
